### PR TITLE
スケジュール、ブログの戻るボタン修正

### DIFF
--- a/app/views/blogs/index.html.erb
+++ b/app/views/blogs/index.html.erb
@@ -48,9 +48,11 @@
   <% end %>
   <br>
   <%= will_paginate(@pblogs, :previous_label => ' &lt 前へ', :next_label => '次へ &gt', class: "pagination justify-content-center mt-6 mb-7 btn--resize", renderer: WillPaginate::ActionView::Bootstrap4LinkRenderer) %>
-  <% if current_staff.present? && current_staff.admin == true %>
-    <%= link_to "戻る", admin_screen_path, class: "btn btn-outline-secondary btn--resize blog-index-return" %>
-  <% elsif current_staff.present? && current_staff.admin == false %>
-    <%= link_to "戻る", staffs_screen_path, class: "btn btn-outline-secondary btn--resize blog-index-return" %>
+  <% if current_staff.present? %>
+    <%= link_to "戻る", staff_toppage_routes(current_staff), class: "btn btn-outline-secondary btn--resize blog-index-return" %>
+  <% elsif current_student.present? %>
+    <%= link_to "戻る", student_toppage_routes(current_student), class: "btn btn-outline-secondary btn--resize blog-index-return" %>
+  <% else %>
+    <%= link_to "戻る", 'https://www.eartherage.com/', class: "btn btn-outline-secondary btn--resize blog-index-return" %>
   <% end %>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -112,8 +112,10 @@
       <!-- 「staff_toppage_routes」はstaffs_helper.rbに記載 -->
       <% if current_staff.present? %>
         <%= link_to "<　戻る", staff_toppage_routes(current_staff), class: "btn btn-outline-secondary" %>
+      <% elsif current_student.present? %>
+        <%= link_to "<　戻る", student_toppage_routes(current_student), class: "btn btn-outline-secondary" %>
       <% else %>
-        <%= link_to "<　戻る", therapist_training_course_path, class: "btn btn-outline-secondary" %>
+        <%= link_to "<　戻る", 'https://www.eartherage.com/', class: "btn btn-outline-secondary" %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
受講生用のイベント・講座一覧画面の戻るボタンのリンク先修正
一般用のイベント・講座一覧画面の戻るボタン追加（リンク先はEartherageHP）
受講生用、一般用のスタッフブログ画面に戻るボタン追加（一般用のリンク先はEartherageHP）